### PR TITLE
Refactor NAS_settings.py to remove global variables

### DIFF
--- a/NAS_arch.py
+++ b/NAS_arch.py
@@ -2,14 +2,13 @@ import ftplib
 import NAS_helper
 import os
 from time import sleep
-import NAS_settings
 
-def seed_arch():
+def seed_arch(settings):
     try:
-        ftp = ftplib.FTP(NAS_settings.arch_server, NAS_settings.arch_user,NAS_settings.arch_pass)
+        ftp = ftplib.FTP(settings.arch_server, settings.arch_user,settings.arch_pass)
 
         #Get arch
-        ftp.cwd(NAS_settings.arch_path)
+        ftp.cwd(settings.arch_path)
 
         #Get torrent list
         dir_raw = []
@@ -17,7 +16,7 @@ def seed_arch():
         torrents = NAS_helper.find_torrents(dir_raw)
 
         for x in range(0,len(torrents)):
-            local_filename = NAS_settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
+            local_filename = settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
             try:
                 lf = open(local_filename, "wb")        
                 ftp.retrbinary("RETR " + torrents[x], lf.write, 8*1024)

--- a/NAS_centos.py
+++ b/NAS_centos.py
@@ -2,14 +2,13 @@ import ftplib
 import NAS_helper
 import os
 from time import sleep
-import NAS_settings
 
-def seed_centos():
+def seed_centos(settings):
     try:
-        ftp = ftplib.FTP(NAS_settings.centos_server, NAS_settings.centos_user,NAS_settings.centos_pass)
+        ftp = ftplib.FTP(settings.centos_server, settings.centos_user,settings.centos_pass)
 
         #Get centos
-        ftp.cwd(NAS_settings.centos_path)
+        ftp.cwd(settings.centos_path)
 
         #Get torrent list
         dir_raw = []
@@ -17,7 +16,7 @@ def seed_centos():
         torrents = NAS_helper.find_torrents(dir_raw)
 
         for x in range(0,len(torrents)):
-            local_filename = NAS_settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
+            local_filename = settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
             try:
                 lf = open(local_filename, "wb")        
                 ftp.retrbinary("RETR " + torrents[x], lf.write, 8*1024)

--- a/NAS_debian.py
+++ b/NAS_debian.py
@@ -2,15 +2,14 @@ import ftplib
 import NAS_helper
 import os
 from time import sleep
-import NAS_settings
 
-def seed_debian():
+def seed_debian(settings):
     #amd64
     try:
-        ftp = ftplib.FTP(NAS_settings.debian_server, NAS_settings.debian_user,NAS_settings.debian_pass)
+        ftp = ftplib.FTP(settings.debian_server, settings.debian_user,settings.debian_pass)
 
         #Get debian
-        ftp.cwd(NAS_settings.debian_path)
+        ftp.cwd(settings.debian_path)
 
         #Get torrent list
         dir_raw = []
@@ -18,7 +17,7 @@ def seed_debian():
         torrents = NAS_helper.find_torrents(dir_raw)
 
         for x in range(0,len(torrents)):
-            local_filename = NAS_settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
+            local_filename = settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
             try:
                 lf = open(local_filename, "wb")        
                 ftp.retrbinary("RETR " + torrents[x], lf.write, 8*1024)
@@ -34,10 +33,10 @@ def seed_debian():
 
     #arm64
     try:
-        ftp = ftplib.FTP(NAS_settings.debian_server, NAS_settings.debian_user,NAS_settings.debian_pass)
+        ftp = ftplib.FTP(settings.debian_server, settings.debian_user,settings.debian_pass)
 
         #Get debian
-        ftp.cwd(NAS_settings.debian_path_arm)
+        ftp.cwd(settings.debian_path_arm)
 
         #Get torrent list
         dir_raw = []
@@ -45,7 +44,7 @@ def seed_debian():
         torrents = NAS_helper.find_torrents(dir_raw)
 
         for x in range(0,len(torrents)):
-            local_filename = NAS_settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
+            local_filename = settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
             try:
                 lf = open(local_filename, "wb")        
                 ftp.retrbinary("RETR " + torrents[x], lf.write, 8*1024)

--- a/NAS_raspbian.py
+++ b/NAS_raspbian.py
@@ -1,12 +1,10 @@
 import NAS_helper
-import NAS_settings
 import os
 from time import sleep
 
-def seed_raspbian():
-
-    for torrent in NAS_settings.raspian_torrents:
-        local_filename = NAS_settings.working_path_NAS + os.sep + torrent.split('/')[-1]
+def seed_raspbian(settings):
+    for torrent in settings.raspian_torrents:
+        local_filename = settings.working_path_NAS + os.sep + torrent.split('/')[-1]
         NAS_helper.grab_file(torrent, local_filename)
 
         print("Attempting to add: " + local_filename)

--- a/NAS_settings.py
+++ b/NAS_settings.py
@@ -1,56 +1,55 @@
 from os.path import expanduser
+from collections import namedtuple
 import tempfile
 
-def init():
-    #Defining constants here
-    
-    #Default working directory. Using home since torrents are deleted after being added
-    global working_path_NAS
-    working_path_NAS = tempfile.gettempdir()
+Settings = namedtuple('Settings', [
+    'working_path_NAS',
+    'ubuntu_server',
+    'ubuntu_path',
+    'ubuntu_user',
+    'ubuntu_pass',
+    'raspian_torrents',
+    'arch_server',
+    'arch_path',
+    'arch_user',
+    'arch_pass',
+    'debian_server',
+    'debian_path',
+    'debian_path_arm',
+    'debian_user',
+    'debian_pass',
+    'centos_server',
+    'centos_path',
+    'centos_user',
+    'centos_pass'
+])
 
-    global ubuntu_server
-    ubuntu_server = "ftp.mirrorservice.org" #University of Kent
-    global ubuntu_path
-    ubuntu_path = "sites/releases.ubuntu.com/"
-    global ubuntu_user
-    ubuntu_user = "anonymous"
-    global ubuntu_pass
-    ubuntu_pass = "anonymous@domain.com"
- 
-    global raspian_torrents
-    raspian_torrents = [
-        "https://downloads.raspberrypi.org/raspbian_full_latest.torrent",
-        "https://downloads.raspberrypi.org/raspbian_latest.torrent",
-        "https://downloads.raspberrypi.org/raspbian_lite_latest.torrent",
-        "https://downloads.raspberrypi.org/NOOBS_latest.torrent",
-        "https://downloads.raspberrypi.org/NOOBS_lite_latest.torrent"
-    ]
-
-    global arch_server
-    arch_server = "ftp.mirrorservice.org" #University of Kent
-    global arch_path
-    arch_path = "sites/ftp.archlinux.org/iso/latest"
-    global arch_user
-    arch_user = "anonymous"
-    global arch_pass
-    arch_pass = "anonymous@domain.com"
-
-    global debian_server
-    debian_server = "cdimage.debian.org"
-    global debian_path
-    debian_path = "/debian-cd/current/amd64/bt-cd"
-    global debian_path_arm
-    debian_path_arm = "/debian-cd/current/arm64/bt-cd"
-    global debian_user
-    debian_user = "anonymous"
-    global debian_pass
-    debian_pass = "anonymous@domain.com"
-
-    global centos_server
-    centos_server = "ftp.mirrorservice.org"
-    global centos_path
-    centos_path = "sites/mirror.centos.org/7/isos/x86_64/"
-    global centos_user
-    centos_user = "anonymous"
-    global centos_pass
-    centos_pass = "anonymous@domain.com"
+def create_settings():
+    '''Populates a namedtuple with the settings defined for the rest of the program'''
+    return Settings(
+        working_path_NAS=tempfile.gettempdir(),
+        ubuntu_server="ftp.mirrorservice.org", #University of Kent
+        ubuntu_path="sites/releases.ubuntu.com/",
+        ubuntu_user="anonymous",
+        ubuntu_pass="anonymous@domain.com",
+        raspian_torrents=[
+            "https://downloads.raspberrypi.org/raspbian_full_latest.torrent",
+            "https://downloads.raspberrypi.org/raspbian_latest.torrent",
+            "https://downloads.raspberrypi.org/raspbian_lite_latest.torrent",
+            "https://downloads.raspberrypi.org/NOOBS_latest.torrent",
+            "https://downloads.raspberrypi.org/NOOBS_lite_latest.torrent"
+        ],
+        arch_server="ftp.mirrorservice.org", #University of Kent
+        arch_path="sites/ftp.archlinux.org/iso/latest",
+        arch_user="anonymous",
+        arch_pass="anonymous@domain.com",
+        debian_server="cdimage.debian.org",
+        debian_path="/debian-cd/current/amd64/bt-cd",
+        debian_path_arm="/debian-cd/current/arm64/bt-cd",
+        debian_user="anonymous",
+        debian_pass="anonymous@domain.com",
+        centos_server="ftp.mirrorservice.org",
+        centos_path="sites/mirror.centos.org/7/isos/x86_64/",
+        centos_user="anonymous",
+        centos_pass="anonymous@domain.com"
+    )

--- a/NAS_ubuntu.py
+++ b/NAS_ubuntu.py
@@ -2,14 +2,13 @@ import ftplib
 import NAS_helper
 import os
 from time import sleep
-import NAS_settings
 
-def seed_ubuntu():
+def seed_ubuntu(settings):
     try:  
-        ftp = ftplib.FTP(NAS_settings.ubuntu_server, NAS_settings.ubuntu_user,NAS_settings.ubuntu_pass)
+        ftp = ftplib.FTP(settings.ubuntu_server, settings.ubuntu_user,settings.ubuntu_pass)
 
         #Get ubuntu
-        ftp.cwd(NAS_settings.ubuntu_path)
+        ftp.cwd(settings.ubuntu_path)
     
         #Get directory listing
         dir_raw = []
@@ -27,7 +26,7 @@ def seed_ubuntu():
         torrents = NAS_helper.find_torrents(dir_raw)
 
         for x in range(0,len(torrents)):
-            local_filename = NAS_settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
+            local_filename = settings.working_path_NAS + os.sep + torrents[x] #Save it in location defined in settings.py
             print(local_filename)
             try:
                 lf = open(local_filename, "wb")        

--- a/main.py
+++ b/main.py
@@ -6,10 +6,14 @@ import NAS_arch
 import NAS_debian
 import NAS_centos
 
-NAS_settings.init()
+def main():
+    settings = NAS_settings.create_settings()
+    NAS_ubuntu.seed_ubuntu(settings)
+    NAS_raspbian.seed_raspbian(settings)
+    NAS_arch.seed_arch(settings)
+    NAS_debian.seed_debian(settings)
+    NAS_centos.seed_centos(settings)
 
-NAS_ubuntu.seed_ubuntu()
-NAS_raspbian.seed_raspbian()
-NAS_arch.seed_arch()
-NAS_debian.seed_debian()
-NAS_centos.seed_centos()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hey there! I like this script, I think it's a great idea and really lowers the barrier to seeding a lot of open-source data at once. I took a look through the code and refactored out the global variables in `NAS_settings.py` by creating a `namedtuple` which holds all the settings data and changing each `seed_*` function to accept that settings tuple as a parameter. I chose the `collections.namedtuple` module because it allows you to use dot-notation to access each field, which is close to the existing pattern in the code (`NAS_settings.foo` becomes `settings.foo`).

I also moved the code in `main.py` within a `main()` function and called that main function within the `if '__name__' == __main__` block. This reorganization is useful in case we ever decide to put code in `main.py` that can be imported from elsewhere. Code that's not contained within functions will be run as a side-effect of importing `main.py`, but by putting it within a function & gating it with the `__name__` check will guarantee that it'll only be invoked if the importee wants it to run explicitly.

Thanks again for making this, I look forward to contributing more!