### PR TITLE
Add option for output dir

### DIFF
--- a/NAS_arch.py
+++ b/NAS_arch.py
@@ -24,6 +24,8 @@ def seed_arch(settings):
                 lf.close()
                 print("Attempting to add: "+local_filename)
                 os.system("deluge-console add "+local_filename)
+                if settings.output_dir_set:
+                    continue
                 sleep(1) #Give deluge some time to add it before deleting file
                 if os.path.exists(local_filename):
                     os.remove(local_filename)

--- a/NAS_centos.py
+++ b/NAS_centos.py
@@ -23,6 +23,8 @@ def seed_centos(settings):
             finally:
                 lf.close()
                 print("Attempting to add: "+local_filename)
+                if settings.output_dir_set:
+                    continue
                 os.system("deluge-console add "+local_filename)
                 sleep(1) #Give deluge some time to add it before deleting file
                 if os.path.exists(local_filename):

--- a/NAS_debian.py
+++ b/NAS_debian.py
@@ -24,6 +24,8 @@ def seed_debian(settings):
             finally:
                 lf.close()
                 print("Attempting to add: "+local_filename)
+                if settings.output_dir_set:
+                    continue
                 os.system("deluge-console add "+local_filename)
                 sleep(1) #Give deluge some time to add it before deleting file
                 if os.path.exists(local_filename):
@@ -52,6 +54,8 @@ def seed_debian(settings):
                 lf.close()
                 print("Attempting to add: "+local_filename)
                 os.system("deluge-console add "+local_filename)
+                if settings.output_dir_set:
+                    continue
                 sleep(1) #Give deluge some time to add it before deleting file
                 if os.path.exists(local_filename):
                     os.remove(local_filename)

--- a/NAS_raspbian.py
+++ b/NAS_raspbian.py
@@ -8,6 +8,9 @@ def seed_raspbian(settings):
         NAS_helper.grab_file(torrent, local_filename)
 
         print("Attempting to add: " + local_filename)
+        if settings.output_dir_set:
+            continue
+
         os.system("deluge-console add " + local_filename)
 
         sleep(1) #Give deluge some time to add it before deleting file

--- a/NAS_settings.py
+++ b/NAS_settings.py
@@ -4,6 +4,7 @@ import tempfile
 
 Settings = namedtuple('Settings', [
     'working_path_NAS',
+    'output_dir_set',
     'ubuntu_server',
     'ubuntu_path',
     'ubuntu_user',
@@ -28,6 +29,7 @@ def create_settings():
     '''Populates a namedtuple with the settings defined for the rest of the program'''
     return Settings(
         working_path_NAS=tempfile.gettempdir(),
+        output_dir_set=False,
         ubuntu_server="ftp.mirrorservice.org", #University of Kent
         ubuntu_path="sites/releases.ubuntu.com/",
         ubuntu_user="anonymous",

--- a/NAS_ubuntu.py
+++ b/NAS_ubuntu.py
@@ -34,6 +34,8 @@ def seed_ubuntu(settings):
             finally:
                 lf.close()
                 print("Attempting to add: "+local_filename)
+                if settings.output_dir_set:
+                    continue
                 os.system("deluge-console add "+local_filename)
                 sleep(1) #Give deluge some time to add it before deleting file
                 if os.path.exists(local_filename):

--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+import os
+import click
+
 import NAS_settings
 import NAS_ubuntu
 import NAS_helper
@@ -6,8 +9,20 @@ import NAS_arch
 import NAS_debian
 import NAS_centos
 
-def main():
+
+@click.command()
+@click.option('-o', '--output-dir',
+              help='Save torrents in dir instead of submitting to deluge',
+              type=click.Path(file_okay=False, writable=True))
+def main(output_dir):
     settings = NAS_settings.create_settings()
+
+    # Configure output dir
+    if output_dir:
+        os.mkdir(output_dir, 0o750)
+        settings = settings._replace(working_path_NAS=output_dir)
+        settings = settings._replace(output_dir_set=True)
+
     NAS_ubuntu.seed_ubuntu(settings)
     NAS_raspbian.seed_raspbian(settings)
     NAS_arch.seed_arch(settings)


### PR DESCRIPTION
This PR adds a CLI option which allows the user to specifically select the output dir. This will result in all torrents being saved in that dir instead of being upload via the Deluge CLI.

I'm aware that this is not the most elegant solution but it is the best I could come up with without changing the code that much.